### PR TITLE
fix: support binary rename patches

### DIFF
--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -85,7 +85,7 @@ binary_merge_conflict_diff
 
 rename_or_copy_diff
   = rename_or_copy_diff_header_line modes:changed_file_modes? similarity:similarity_index copy_from:rename_copy_from copy_to:rename_copy_to
-    index_modes:index_line? patch:patch?
+    index_modes:index_line? patch:(binary_declaration / patch)?
   {
     return postProcessSimilarityDiff(copy_from.operation, similarity, copy_from.file, copy_to.file, modes || index_modes, patch)
   }

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -521,6 +521,28 @@ exports.testBinaryFiles = function(test) {
   test.done()
 }
 
+exports.testBinaryFilesRename = function(test) {
+  var str = dedent`
+    diff --git a/dir_a/one.png b/dir_b/one.png
+    similarity index 100%
+    rename from dir_a/one.png
+    rename to dir_b/one.png
+    Binary files differ
+  `
+
+  const output = diff.parse(str)
+  assert.deepEqual(output, [
+    {
+      oldPath: 'dir_a/one.png',
+      newPath: 'dir_b/one.png',
+      hunks: undefined,
+      status: 'renamed',
+      similarity: 100
+    }
+  ])
+  test.done()
+}
+
 exports.testNoPatch = function(test) {
   var str = dedent`
   diff --git file.txt file.txt


### PR DESCRIPTION
example from the wild: https://chromium.googlesource.com/chromium/src/+/22b5144060f40e96f2e7faba8d5c15a288f6d0f7%5E%21/

```diff
diff --git a/chrome/android/java/res_autofill_assistant/drawable-hdpi/autofill_assistant_bottombar_bg.9.png b/chrome/android/features/autofill_assistant/java/res/drawable-hdpi/autofill_assistant_bottombar_bg.
9.png
similarity index 100%
rename from chrome/android/java/res_autofill_assistant/drawable-hdpi/autofill_assistant_bottombar_bg.9.png
rename to chrome/android/features/autofill_assistant/java/res/drawable-hdpi/autofill_assistant_bottombar_bg.9.png
Binary files differ
```

This is currently failing with a parse error.